### PR TITLE
Fix some cases when there are empty names

### DIFF
--- a/lib/c2ffi4rb/parser.rb
+++ b/lib/c2ffi4rb/parser.rb
@@ -100,7 +100,8 @@ module C2FFI4RB
       name = 'C' + name if name.start_with? '_'
 
       # Convert snake_case to CamelCase
-      name = name.capitalize.gsub!(/_([a-z])/) { |m| "_#{m[1].upcase}" }
+      name.capitalize!
+      name.gsub!(/_([a-z])/) { |m| "_#{m[1].upcase}" }
 
       @struct_type << name unless @struct_type.include? name
       name

--- a/lib/c2ffi4rb/parser.rb
+++ b/lib/c2ffi4rb/parser.rb
@@ -123,7 +123,7 @@ module C2FFI4RB
     def make_struct(form)
       name = add_struct(form[:name])
 
-      type = if form[:tag] == ':struct'
+      type = if form[:tag] == 'struct'
                'FFI::Struct'
              else
                'FFI::Union'

--- a/lib/c2ffi4rb/parser.rb
+++ b/lib/c2ffi4rb/parser.rb
@@ -135,9 +135,15 @@ module C2FFI4RB
       if form[:fields].length.positive?
         l << '  layout \\'
         size = form[:fields].length
+        anon_field_counter = 0
         form[:fields].each_with_index do |f, i|
           sep = i >= (size - 1) ? '' : ','
-          l << "    :#{f[:name]}, #{parse_type(f[:type])}#{sep}"
+          field_name = f[:name]
+          if field_name.empty?
+            field_name = "anon_field_#{anon_field_counter}"
+            anon_field_counter += 1
+          end
+          l << "    :#{field_name}, #{parse_type(f[:type])}#{sep}"
         end
       end
       l << 'end'

--- a/test/c2ffi4rb/parser_test.rb
+++ b/test/c2ffi4rb/parser_test.rb
@@ -1,0 +1,18 @@
+require_relative '../test_helper'
+
+module C2FFI4RB
+  class ParserTest < Minitest::Test
+    def test_make_struct_with_simple_struct
+      parser = C2FFI4RB::Parser.new
+      form = { tag: 'struct',
+               ns: 0,
+               name: 'GTestSuite',
+               id: 0,
+               location: '/path/to/include/glib-2.0/glib/gtestutils.h:36:16',
+               "bit-size": 0,
+               "bit-alignment": 0,
+               fields: [] }
+      assert_equal "class Gtestsuite < FFI::Struct\nend", parser.send(:make_struct, form)
+    end
+  end
+end

--- a/test/c2ffi4rb/parser_test.rb
+++ b/test/c2ffi4rb/parser_test.rb
@@ -14,5 +14,22 @@ module C2FFI4RB
                fields: [] }
       assert_equal "class Gtestsuite < FFI::Struct\nend", parser.send(:make_struct, form)
     end
+
+    def test_make_struct_with_form_which_has_anonymous_field
+      parser = C2FFI4RB::Parser.new
+      form = { tag: 'struct', ns: 0, name: 'Sigcontext', id: 0,
+               location: '/path/to/include/bits/modified_sigcontext.h:139:8',
+               "bit-size": 2048,
+               "bit-alignment": 64,
+               fields: [{ tag: 'field',
+                          name: '', # empty name here!
+                          "bit-offset": 1472, "bit-size": 64, "bit-alignment": 64,
+                          type: { tag: 'union', ns: 0, name: '', id: 84, location: '/path/to/include/bits/sigcontext.h:167:17', "bit-size": 64, "bit-alignment": 64,
+                                  fields: [{ tag: 'field', name: 'fpstate', "bit-offset": 0, "bit-size": 64, "bit-alignment": 64,
+                                             type: { tag: ':pointer', type: { tag: ':struct', name: '_fpstate', id: 85 } } },
+                                           { tag: 'field', name: '__fpstate_word', "bit-offset": 0, "bit-size": 64, "bit-alignment": 64,
+                                             type: { tag: '__uint64_t' } }] } }] }
+      assert_equal "class Sigcontext < FFI::Struct\n  layout \\\n    :anon_field_0, Anon_Type_1\nend", parser.send(:make_struct, form)
+    end
   end
 end


### PR DESCRIPTION
Hello,

This pull request fixes some cases in which a form has some empty names in types or fields.

* Struct names without the pattern `/_([a-z])/` were empty by the string manipulation `gsub!`. Fixed in da548dc77d889fc2ea7ce5e63d0dd340e852369c.
* Add a support for empty field names by naming them as anonymous. Fixed in 9bc44dfa4989da760a177a17dc7fb56237777458.

The latter case is a little bit tricky.
Here is an example from `/path/to/include/bits/sigcontext.h`.
The field which contains `__extension__ union` doesn't have its name and thus the name field becomes empty.

```c
struct sigcontext
{
  __uint64_t r8;
  __uint64_t r9;
  __uint64_t r10;
  __uint64_t r11;
  __uint64_t r12;
  __uint64_t r13;
  __uint64_t r14;
  __uint64_t r15;
  __uint64_t rdi;
  __uint64_t rsi;
  __uint64_t rbp;
  __uint64_t rbx;
  __uint64_t rdx;
  __uint64_t rax;
  __uint64_t rcx;
  __uint64_t rsp;
  __uint64_t rip;
  __uint64_t eflags;
  unsigned short cs;
  unsigned short gs;
  unsigned short fs;
  unsigned short __pad0;
  __uint64_t err;
  __uint64_t trapno;
  __uint64_t oldmask;
  __uint64_t cr2;
  __extension__ union
    {
      struct _fpstate * fpstate;
      __uint64_t __fpstate_word;
    };
  __uint64_t __reserved1 [8];
};
```

<details>
<summary>license of the snippet</summary>

```c
/* Copyright (C) 2002-2022 Free Software Foundation, Inc.
   This file is part of the GNU C Library.

   The GNU C Library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
   License as published by the Free Software Foundation; either
   version 2.1 of the License, or (at your option) any later version.

   The GNU C Library is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
   Lesser General Public License for more details.

   You should have received a copy of the GNU Lesser General Public
   License along with the GNU C Library; if not, see
   <https://www.gnu.org/licenses/>.  */
```

</details>

Also it now properly detects struct types when form's field tag value is `struct`.
Fixed in c2bb84ec452fedb87f384c86484c4d3cae5dce27 along the way above.

Thank you,
gemmaro.